### PR TITLE
[HQRPP-22973] version bump 3.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bellese/angular-design-system",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
Publishing to npm registry need to bump version.