### PR TITLE
HQRPP-25359 508 fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bellese/angular-design-system",
-  "version": "3.0.26",
+  "version": "3.0.27",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/modules/table2/table-header/table-header.component.html
+++ b/src/app/modules/table2/table-header/table-header.component.html
@@ -2,7 +2,7 @@
   <ng-container *ngSwitchCase="TableHeaderTypeEnum.SORT">
     <app-button
       [title]="tableHeaderModel.label"
-      [ariaLabel]="'Activate to sort' + tableHeaderModel.label + 'column'"
+      [ariaLabel]="'Activate to sort ' + tableHeaderModel.label + ' column'"
       [buttonID]="'header_' + tableHeaderModel.columnKey"
       (callBack)="headerClickEvent($event)"
       buttonType="ds-u-padding--0 ds-u-border--0 ds-u-color--base"


### PR DESCRIPTION
- Aria labels for UM table column headers, put space in-between sortNamecolumn and sortEmailColumn, otherwise JAWS reads it all together and it doesn't make sense.

