### PR TITLE
fix(dropdown-component): if no default selection was passed into the …

### DIFF
--- a/src/app/modules/drop-down/drop-down.component.ts
+++ b/src/app/modules/drop-down/drop-down.component.ts
@@ -13,7 +13,7 @@ export class AppDropDownComponent implements OnInit, OnChanges {
   @Input() ariaLabel: string;
   @Input() id = 1;
   @Input() defaultSelected = 0;
-  @Input() defaultSelectedValue = '';
+  @Input() defaultSelectedValue: string = null;
   @Input() hintMessage: string;
   @Input() errorMessage: string;
   @Input() error: boolean;
@@ -44,9 +44,9 @@ export class AppDropDownComponent implements OnInit, OnChanges {
   }
 
   setSelectedValue() {
-    if (this.defaultSelectedValue) {
+    if (this.defaultSelectedValue !== null) {
       this.control?.setValue(this.defaultSelectedValue);
-    } else if (this.defaultSelected) {
+    } else if (this.defaultSelected !== null) {
       this.control?.setValue(this.options[this.defaultSelected].value);
     }
   }


### PR DESCRIPTION
…component, the first option is supposed to be selected, but that broke due to the recent formly/angular-forms integration