### PR TITLE
Feature: Card Cluster Custom Title Styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bellese/angular-design-system",
-  "version": "4.0.9",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bellese/angular-design-system",
-  "version": "4.2.3",
+  "version": "4.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/app/modules/card-cluster/card-cluster.component.html
+++ b/src/app/modules/card-cluster/card-cluster.component.html
@@ -31,7 +31,7 @@
           </app-choice>
         </div>
         <div class="ds-l-col" [ngClass]="{ 'ds-u-padding-left--0': cardArray.showRadioButton }">
-          <div class="ds-u-font-size--h1 ds-u-color--black noPoint">
+          <div class="ds-u-color--black noPoint" [ngClass]="cardArray.mainTitleClass !== undefined ? cardArray.mainTitleClass : 'ds-u-font-size--h1'">
             <fa-icon [icon]="cardArray.mainTitleIcon" *ngIf="cardArray.mainTitleIcon"></fa-icon>
             {{ cardArray.mainTitle || '&nbsp;' }}
           </div>

--- a/src/app/modules/card-cluster/card-cluster.models.ts
+++ b/src/app/modules/card-cluster/card-cluster.models.ts
@@ -22,6 +22,7 @@ export class CardClusterModel extends AngularDesignSystemModel {
   mainCard = true;
   mainTitle?: string;
   mainTitleIcon?: IconDefinition;
+  mainTitleClass?: string;
   mainSub?: string;
   total?: number | string;
   ariaLabel?: string;

--- a/src/app/modules/card-cluster/card-cluster.stories.ts
+++ b/src/app/modules/card-cluster/card-cluster.stories.ts
@@ -80,6 +80,12 @@ const cardClusterDataShowRadioButtons = {
   showRadioButton: true,
 };
 
+const cardClusterDataLongNameWithCustomStyle = {
+  ...cardClusterDataNormal,
+  mainTitle: 'Safe Use of Opioids',
+  mainTitleClass: 'ds-u-font-size--h2'
+}
+
 const cardClusterDataShowRadioButtonsAndIcons = new CardClusterModel({
   mainCard: false,
   showRadioButton: true,
@@ -117,6 +123,7 @@ const props = {
   cardClusterDataShowRadioButtons,
   cardClusterDataShowRadioButtonsAndIcons,
   cardClusterDataDisabledCards,
+  cardClusterDataLongNameWithCustomStyle,
 };
 
 export default {
@@ -358,6 +365,16 @@ export const DisabledCards: Story<AppCardClusterComponent> = () => ({
   template: `
     <app-card-cluster
       [cardArray]="cardClusterDataDisabledCards"
+      (passButton)="handleEvent($event)">
+    </app-card-cluster>
+  `,
+  props,
+});
+
+export const LongNameCustomTitleClass: Story<AppCardClusterComponent> = () => ({
+  template: `
+    <app-card-cluster
+      [cardArray]="cardClusterDataLongNameWithCustomStyle"
       (passButton)="handleEvent($event)">
     </app-card-cluster>
   `,


### PR DESCRIPTION
- Add new optional parameter to card cluster model to change styling of main card title
- Add accompanying story

<img width="1351" alt="Screen Shot 2021-09-22 at 1 17 47 PM" src="https://user-images.githubusercontent.com/39271238/134412587-7ac39e7b-b579-4109-ac6c-e1d73642f24f.png">
