### PR TITLE
508, a11y fix for app-panel to avoid button nesting, screen reader confusion

### DIFF
--- a/src/app/modules/panel/panel.component.css
+++ b/src/app/modules/panel/panel.component.css
@@ -1,6 +1,11 @@
 .panel {
   padding: 3px;
 }
+
+.plusIcon {
+  width: 16px;
+}
+
 .plusIcon fa-icon {
   -moz-transition: all 0.3s ease;
   transition: all 0.3s ease;

--- a/src/app/modules/panel/panel.component.html
+++ b/src/app/modules/panel/panel.component.html
@@ -2,7 +2,6 @@
   <!-- Some padding classes are controlled in the component.ts file -->
   <div
     class="plusIcon"
-    [ngClass]="plusIconClass"
     (click)="plusActionClick($event)"
     (keyup.enter)="plusActionClick($event)"
   >
@@ -29,54 +28,57 @@
       <div class="ds-l-row">
         <!-- Left Icon -->
         <div
-          class="ds-l-col--auto ds-u-padding-left--0 ds-u-padding-right--2"
+          class="ds-l-col--auto"
+          [ngClass]="plusIconClass"
           *ngIf="iconPlacement === PanelIconPlacementEnum.LEFT"
         >
-          <ng-container>
-            <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
-          </ng-container>
+          <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
         </div>
         <!-- Title -->
         <div class="title ds-l-col--auto ds-u-padding-left--0">
           <ng-container *ngIf="title; else titleComplex">{{
             titleExpanded && (expand || openAll) ? titleExpanded : title
           }}</ng-container>
+          <!-- This 'select' means any <ng-container> between <app-panel> tags will be the Title content -->
           <ng-template #titleComplex><ng-content select="ng-container"></ng-content></ng-template>
         </div>
         <!-- Inline Icon -->
-        <ng-container *ngIf="iconPlacement === PanelIconPlacementEnum.INLINE">
+        <div *ngIf="iconPlacement === PanelIconPlacementEnum.INLINE" [ngClass]="plusIconClass">
           <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
-        </ng-container>
+        </div>
       </div>
     </div>
 
     <!-- Extra title, often an app-button which contains a span, as 'select'ed below -->
     <div [ngClass]="extTitleClass" class="ds-l-col--auto">
       <div class="ds-l-row ds-u-margin-left--auto">
+        <!-- Right Text / Title / Button -->
+        <!-- This 'select' means any <span> between <app-panel> tags will be the Right Text -->
         <ng-content *ngIf="extTitle" select="span"></ng-content>
         <!-- Right Icon - click behavior identical to "clickable group" above -->
         <div
           *ngIf="iconPlacement === PanelIconPlacementEnum.RIGHT"
+          [ngClass]="plusIconClass"
           (click)="panelStateChange($event)"
           (keyup.enter)="panelStateChange($event)"
+          tabindex="0"
           role="button"
           [attr.aria-expanded]="expand || openAll"
         >
-          <ng-container>
-            <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
-          </ng-container>
+          <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
         </div>
-        <div class="ds-u-padding-right--2"></div>
       </div>
     </div>
   </div>
 </ng-template>
 
+<!-- Panel body / content -->
 <div class="ds-l-container ds-u-margin-bottom--3 ds-u-padding--0">
   <ng-container *ngIf="titlePlacement === PanelTitlePlacementEnum.TOP">
     <ng-container *ngTemplateOutlet="panelTitle"></ng-container>
   </ng-container>
 
+  <!-- This 'select' means any <div> between <app-panel> tags will be the panel content -->
   <div *ngIf="expand || openAll" [@fadeInTrigger]="expand" [ngClass]="expandedClass">
     <ng-content select="div"></ng-content>
   </div>

--- a/src/app/modules/panel/panel.component.html
+++ b/src/app/modules/panel/panel.component.html
@@ -1,6 +1,7 @@
 <ng-template #plusIcon>
   <div
-    class="ds-l-col--auto plusIcon ds-u-padding--0"
+    class="plusIcon"
+    [ngClass]="plusIconClass"
     (click)="plusActionClick($event)"
     (keyup.enter)="plusActionClick($event)"
   >
@@ -11,38 +12,58 @@
 
 <ng-template #panelTitle>
   <div
-    class="ds-l-row ds-u-align-items--top ds-u-justify-content--center ds-u-margin--0 pointer panel"
+    class="ds-l-row ds-u-align-items--top ds-u-margin--0 panel"
     [ngClass]="titleClass"
-    (click)="panelStateChange($event)"
-    (keyup.enter)="panelStateChange($event)"
-    tabindex="0"
-    role="button"
-    [attr.aria-expanded]="expand || openAll"
-    attr.data-auto-id="{{ dataAutoId }}"
   >
-    <ng-container *ngIf="iconPlacement === PanelIconPlacementEnum.LEFT">
-      <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
-      <div class="ds-l-col--auto"></div>
-    </ng-container>
-
-    <div class="ds-l-col--auto ds-u-padding-left--0 title">
-      <ng-container *ngIf="title; else titleComplex">{{
-        titleExpanded && (expand || openAll) ? titleExpanded : title
-      }}</ng-container>
-      <ng-template #titleComplex><ng-content select="ng-container"></ng-content></ng-template>
+    <div
+      (click)="panelStateChange($event)"
+      (keyup.enter)="panelStateChange($event)"
+      tabindex="0"
+      role="button"
+      [attr.aria-expanded]="expand || openAll"
+      attr.data-auto-id="{{ dataAutoId }}"
+      class="ds-l-col pointer"
+    >
+      <div class="ds-l-row">
+        <div
+          class="ds-l-col--auto ds-u-padding-left--0 ds-u-padding-right--2"
+          *ngIf="iconPlacement === PanelIconPlacementEnum.LEFT"
+        >
+          <ng-container>
+            <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
+          </ng-container>
+        </div>
+        <div class="title ds-l-col--auto ds-u-padding-left--0">
+          <ng-container *ngIf="title; else titleComplex">{{
+            titleExpanded && (expand || openAll) ? titleExpanded : title
+          }}</ng-container>
+          <ng-template #titleComplex><ng-content select="ng-container"></ng-content></ng-template>
+        </div>
+        <ng-container *ngIf="iconPlacement === PanelIconPlacementEnum.INLINE">
+          <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
+        </ng-container>
+      </div>
     </div>
-    <ng-container *ngIf="iconPlacement === PanelIconPlacementEnum.INLINE">
-      <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
-    </ng-container>
 
-    <div [ngClass]="extTitleClass" class="extTitle ds-l-col ds-u-text-align--right">
-      <ng-content *ngIf="extTitle" select="span"></ng-content>
+    <div [ngClass]="extTitleClass" class="ds-l-col--auto">
+      <div class="ds-l-row ds-u-margin-left--auto">
+        <ng-content *ngIf="extTitle" select="span"></ng-content>
+        <div
+          *ngIf="iconPlacement === PanelIconPlacementEnum.RIGHT"
+          (click)="panelStateChange($event)"
+          (keyup.enter)="panelStateChange($event)"
+          tabindex="0"
+          role="button"
+          [attr.aria-expanded]="expand || openAll"
+          attr.data-auto-id="{{ dataAutoId }}"
+        >
+          <ng-container>
+            <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
+          </ng-container>
+        </div>
+        <div class="ds-u-padding-right--2"></div>
+      </div>
     </div>
-
-    <ng-container *ngIf="iconPlacement === PanelIconPlacementEnum.RIGHT">
-      <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
-      <div class="ds-l-col--auto"></div>
-    </ng-container>
   </div>
 </ng-template>
 

--- a/src/app/modules/panel/panel.component.html
+++ b/src/app/modules/panel/panel.component.html
@@ -1,4 +1,5 @@
 <ng-template #plusIcon>
+  <!-- Some padding classes are controlled in the component.ts file -->
   <div
     class="plusIcon"
     [ngClass]="plusIconClass"
@@ -15,6 +16,7 @@
     class="ds-l-row ds-u-align-items--top ds-u-margin--0 panel"
     [ngClass]="titleClass"
   >
+    <!-- clickable group of possible icons and title fills most of the outmost row -->
     <div
       (click)="panelStateChange($event)"
       (keyup.enter)="panelStateChange($event)"
@@ -25,6 +27,7 @@
       class="ds-l-col pointer"
     >
       <div class="ds-l-row">
+        <!-- Left Icon -->
         <div
           class="ds-l-col--auto ds-u-padding-left--0 ds-u-padding-right--2"
           *ngIf="iconPlacement === PanelIconPlacementEnum.LEFT"
@@ -33,29 +36,31 @@
             <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
           </ng-container>
         </div>
+        <!-- Title -->
         <div class="title ds-l-col--auto ds-u-padding-left--0">
           <ng-container *ngIf="title; else titleComplex">{{
             titleExpanded && (expand || openAll) ? titleExpanded : title
           }}</ng-container>
           <ng-template #titleComplex><ng-content select="ng-container"></ng-content></ng-template>
         </div>
+        <!-- Inline Icon -->
         <ng-container *ngIf="iconPlacement === PanelIconPlacementEnum.INLINE">
           <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
         </ng-container>
       </div>
     </div>
 
+    <!-- Extra title, often an app-button which contains a span, as 'select'ed below -->
     <div [ngClass]="extTitleClass" class="ds-l-col--auto">
       <div class="ds-l-row ds-u-margin-left--auto">
         <ng-content *ngIf="extTitle" select="span"></ng-content>
+        <!-- Right Icon - click behavior identical to "clickable group" above -->
         <div
           *ngIf="iconPlacement === PanelIconPlacementEnum.RIGHT"
           (click)="panelStateChange($event)"
           (keyup.enter)="panelStateChange($event)"
-          tabindex="0"
           role="button"
           [attr.aria-expanded]="expand || openAll"
-          attr.data-auto-id="{{ dataAutoId }}"
         >
           <ng-container>
             <ng-container *ngTemplateOutlet="plusIcon"></ng-container>

--- a/src/app/modules/panel/panel.component.ts
+++ b/src/app/modules/panel/panel.component.ts
@@ -30,7 +30,7 @@ export class AppPanelComponent implements OnInit {
   @Input() iconExpanded = faMinus;
   @Input() iconPlacement: PanelIconPlacementEnum = PanelIconPlacementEnum.LEFT;
 
-  clicked;
+  clicked = false;
   PanelIconPlacementEnum = PanelIconPlacementEnum;
   PanelTitlePlacementEnum = PanelTitlePlacementEnum;
   plusIconClass = 'pointer ds-u-padding-x--0';

--- a/src/app/modules/panel/panel.component.ts
+++ b/src/app/modules/panel/panel.component.ts
@@ -15,7 +15,7 @@ export class AppPanelComponent implements OnInit {
   @Input() title: string;
   @Input() titleExpanded: string;
   @Input() titleClass =
-    'ds-u-fill--primary-darkest ds-u-color--white ds-u-font-size--h4 ds-u-md-font-size--h3 ds-u-padding--2';
+    'ds-u-fill--primary-darkest ds-u-color--white ds-u-font-size--h4 ds-u-md-font-size--h3 ds-u-padding-left--2 ds-u-padding-right--4 ds-u-padding-y--2';
   @Input() titlePlacement: PanelTitlePlacementEnum = PanelTitlePlacementEnum.TOP;
 
   @Input() extTitle = false;
@@ -33,7 +33,7 @@ export class AppPanelComponent implements OnInit {
   clicked = false;
   PanelIconPlacementEnum = PanelIconPlacementEnum;
   PanelTitlePlacementEnum = PanelTitlePlacementEnum;
-  plusIconClass = 'pointer ds-u-padding-x--0';
+  plusIconClass = 'pointer ds-u-padding-left--0';
 
   constructor() {}
 

--- a/src/app/modules/panel/panel.component.ts
+++ b/src/app/modules/panel/panel.component.ts
@@ -33,10 +33,15 @@ export class AppPanelComponent implements OnInit {
   clicked;
   PanelIconPlacementEnum = PanelIconPlacementEnum;
   PanelTitlePlacementEnum = PanelTitlePlacementEnum;
+  plusIconClass = 'pointer ds-u-padding-x--0';
 
   constructor() {}
 
   ngOnInit() {
+    if (this.iconPlacement === PanelIconPlacementEnum.RIGHT) {
+      this.plusIconClass = 'pointer ds-u-padding-left--2';
+    }
+
     if (this.expand) {
       this.clicked = true;
     }

--- a/src/app/modules/panel/panel.stories.ts
+++ b/src/app/modules/panel/panel.stories.ts
@@ -207,7 +207,8 @@ export const CustomIcon: Story<AppPanelComponent> = () => ({
   props,
 });
 
-export const CustomIconWithButton: Story<AppPanelComponent> = () => ({
+
+export const CustomIconAndExpandedTitle: Story<AppPanelComponent> = () => ({
   template: `
             <app-panel
                 (panelClick) = "handleEvent($event)"
@@ -221,7 +222,31 @@ export const CustomIconWithButton: Story<AppPanelComponent> = () => ({
                 [iconExpanded] = "faChevronUp"
             >
                 <span>
-                    <button class="ds-c-button ds-c-button--transparent ds-u-padding-y--0">A Button</button>
+                    Additional Title
+                </span>
+                <div>
+                    Panel Content
+                </div>
+            </app-panel>
+        `,
+  props,
+});
+
+export const CustomIconAndExpandedButton: Story<AppPanelComponent> = () => ({
+  template: `
+            <app-panel
+                (panelClick) = "handleEvent($event)"
+                title ='Panel Example'
+                extTitleClass = 'customizeExtra'
+                dataAutoId = 'dataID'
+                [extTitle] = true
+                [expand] = false
+                [openAll] = false
+                [icon] = "faChevronDown"
+                [iconExpanded] = "faChevronUp"
+            >
+                <span>
+                    <button class="ds-c-button ds-c-button--transparent ds-u-padding--0">A Button</button>
                 </span>
                 <div>
                     Panel Content

--- a/src/app/modules/panel/panel.stories.ts
+++ b/src/app/modules/panel/panel.stories.ts
@@ -178,9 +178,6 @@ export const Normal: Story<AppPanelComponent> = () => ({
                 [expand] = false
                 [openAll] = false
             >
-                <span>
-                    Additional Title
-                </span>
                 <div>
                     Panel Content
                 </div>
@@ -202,8 +199,29 @@ export const CustomIcon: Story<AppPanelComponent> = () => ({
                 [icon] = "faChevronDown"
                 [iconExpanded] = "faChevronUp"
             >
+                <div>
+                    Panel Content
+                </div>
+            </app-panel>
+        `,
+  props,
+});
+
+export const CustomIconWithButton: Story<AppPanelComponent> = () => ({
+  template: `
+            <app-panel
+                (panelClick) = "handleEvent($event)"
+                title ='Panel Example'
+                extTitleClass = 'customizeExtra'
+                dataAutoId = 'dataID'
+                [extTitle] = true
+                [expand] = false
+                [openAll] = false
+                [icon] = "faChevronDown"
+                [iconExpanded] = "faChevronUp"
+            >
                 <span>
-                    Additional Title
+                    <button class="ds-c-button ds-c-button--transparent ds-u-padding-y--0">A Button</button>
                 </span>
                 <div>
                     Panel Content


### PR DESCRIPTION
## Problem

The `app-panel` component wraps the entire panel title bar in a `<div role="button">`. The intent is for the entire panel to be `click`able which with `expand/collapse` the panel contents.

Further, if a developer provides content within `<span>` tags, it will get `select`ed by the component and end up in the "Additional Title" area to the right of the panel title bar.

As a result, If this `<span>` contains `<app-button>` or something else clickable/actionable by the user, it will result in a `button` within a `button`. Even though the outer `button` is technically a `<div>` and all required elements are keyboard accessible, it creates a very confusing situation for a screen reader like JAWS or VoiceOver.

While tabbing back and forth, it will usually read all the panel title text, even when the panel contains a button with different `click` behavior. It will be unclear to the user which element actually has keyboard focus when they activate the `click`.

## Example / HTML signature

This is a "sketch" of how a UI application _consumes/integrates_ this component by using the <app-panel> within their application's HTML templates.

```html
<app-panel>
  <span><app-button></app-button></span
  [...]
</app-panel>
```

Note ... `<app-panel>` will also handle `<ng-container>` and `<div>` for other reasons, but they weren't part of this bug or changed by this fix.

Storybook example: https://bellese.github.io/angular-design-system/?path=/story/components-panel--custom-icon

## Solution

Break the panel bar into multiple elements, so that
1. The `extTitle` (content within `<app-panel><span>[...]`) no longer resides within the rest of the panel's `<div>`(s)
2. The `extTitle` is therefore individually keyboard accessible AND individually read by the screen reader.
3. Add Storybook examples for this case

## Change to default behavior

### Keyboard focus / tabbing

If the `plusIcon` position is `LEFT` or `INLINE` (i.e. grouped with the main `title`), tabbing behavior won't change. However, if it's to the `RIGHT` of the `extTitle` aka "Additional Title / Button", it will get separate tab focus. While it's an extra tab for keyboard navigation/screen reader users, it will at least be clear.

### Clickable area

The clickable area used to fill the entire visible div - the "blue box" as seen in many examples. This change required that this area no longer includes the inner ~16px padding for this box. But the majority of the "center mass" of the Title, plus/arrow/icon, and Additional Title (only when it's a button), is clickable.

### Additional Title

I did my best to leave default behavior as-is. But most usages of `app-panel` with this signature contained `button` of some kind. I think only one did not.

At initial writing of this PR, In the event that `<span>` content is wrapped in an `app-panel` but does NOT contain `click`able content, it will no longer `expand/collapse` the panel content. That said, if this content is just 1-2 words, the vast majority of the panel will still be `click`able.

If required, I might add an optional parameter to make this content share the same `click` behavior, which would restore previous behavior. 