### PR TITLE
fix(app-modal-shell): update modal header

### DIFF
--- a/src/app/modules/modal-shell/modal-shell.component.html
+++ b/src/app/modules/modal-shell/modal-shell.component.html
@@ -1,54 +1,61 @@
-<div id="{{'modalImplementation' + modalCount}}" class="ds-c-dialog-wrap" [attr.aria-modal]="true" [attr.aria-labelledby]="'dialog-title-' + modalCount" [attr.aria-describedby]="'dialog-body-' + modalCount" role="dialog" id="modalDialog" id="modal" (keyDown.esc)="onClose()" attr.data-auto-id="{{dataAutoId}}">
-    <div tabindex="0" class="focus-trap-hidden" id="firstModalTab" (focus)="findTab($event)" aria-hidden="true"></div>
-        <div class="tableClass">
-            <div class="cellClass">
-                <div class="ds-c-dialog {{modalClass}}" role="document">
-                    <app-button
-                        class="floatRight"
-                        (callBack)="onClose()" 
-                        [ariaLabel]="'Close modal dialog'" 
-                        [buttonType]="'modalTabIndex ds-c-button--transparent ds-c-dialog__close'" 
-                        [buttonID]="'closeButton'+modalCount">
-                        Close
-                    </app-button>
-                    
-                    <ng-template #defaultHeader let-modalHeader="modalHeader">
-                        <h1 class="ds-h1" id="{{'dialog-title-' + modalHeader.modalCount}}">
-                            {{modalHeader.modalTitle}}
-                        </h1>
-                    </ng-template>
-                    
-                    <ng-container *ngTemplateOutlet="headerTemplate ? headerTemplate : defaultHeader; context: getTitle">
-                    </ng-container>
+<div id="{{'modalImplementation' + modalCount}}" class="ds-c-dialog-wrap" [attr.aria-modal]="true"
+     [attr.aria-labelledby]="'dialog-title-' + modalCount" [attr.aria-describedby]="'dialog-body-' + modalCount"
+     role="dialog" id="modalDialog" id="modal" (keyDown.esc)="onClose()" attr.data-auto-id="{{dataAutoId}}">
+  <div tabindex="0" class="focus-trap-hidden" id="firstModalTab" (focus)="findTab($event)" aria-hidden="true"></div>
+  <div class="tableClass">
+    <div class="cellClass">
+      <div class="ds-c-dialog {{modalClass}}" role="document">
+        <div class="modal-header-wrapper ds-u-display--flex ds-u-margin-bottom--2">
+          <div class="modal-header-content">
+            <ng-container
+              *ngTemplateOutlet="headerTemplate ? headerTemplate : defaultHeader; context: getTitle">
+            </ng-container>
 
-                    <main [id]="jawsBody ? 'dialog-body-' + modalCount : ''">
-
-                        <ng-template #defaultBody let-modalBody="modalBody">
-                            <p>
-                                {{modalBody.modalData}}
-                            </p>
-                        </ng-template>
-
-                        <ng-container *ngTemplateOutlet="bodyTemplate ? bodyTemplate : defaultBody; context: getBody">
-                        </ng-container>
-
-                        <aside class="ds-c-dialog__actions">
-                            <ng-template #defaultFooter>
-                                <app-button
-                                    (callBack)="onClose()" 
-                                    [ariaLabel]="'Cancel modal'" 
-                                    [buttonType]="'modalTabIndex'" 
-                                    [buttonID]="'cancelButton'+modalCount">
-                                    Cancel
-                                </app-button>
-                            </ng-template>
-
-                            <ng-container *ngTemplateOutlet="footerTemplate ? footerTemplate : defaultFooter">
-                            </ng-container>
-                        </aside>
-                    </main>
-                </div>
-            </div>
+            <ng-template #defaultHeader let-modalHeader="modalHeader">
+              <h2 class="ds-h2"
+                  id="{{'dialog-title-' + modalHeader.modalCount}}">
+                {{modalHeader.modalTitle}}
+              </h2>
+            </ng-template>
+          </div>
+          <app-button
+            class="modal-header-close-button ds-u-margin-left--1"
+            (callBack)="onClose()"
+            [ariaLabel]="'Close modal dialog'"
+            [buttonType]="'modalTabIndex ds-c-button--transparent ds-c-dialog__close'"
+            [buttonID]="'closeButton'+modalCount">
+            Close
+          </app-button>
         </div>
-    <div tabindex="0" class="focus-trap-hidden" id="lastModalTab" (focus)="findTab($event)" aria-hidden="true"></div>
+
+        <main [id]="jawsBody ? 'dialog-body-' + modalCount : ''">
+
+          <ng-template #defaultBody let-modalBody="modalBody">
+            <p>
+              {{modalBody.modalData}}
+            </p>
+          </ng-template>
+
+          <ng-container *ngTemplateOutlet="bodyTemplate ? bodyTemplate : defaultBody; context: getBody">
+          </ng-container>
+
+          <aside class="ds-c-dialog__actions">
+            <ng-template #defaultFooter>
+              <app-button
+                (callBack)="onClose()"
+                [ariaLabel]="'Cancel modal'"
+                [buttonType]="'modalTabIndex'"
+                [buttonID]="'cancelButton'+modalCount">
+                Cancel
+              </app-button>
+            </ng-template>
+
+            <ng-container *ngTemplateOutlet="footerTemplate ? footerTemplate : defaultFooter">
+            </ng-container>
+          </aside>
+        </main>
+      </div>
+    </div>
+  </div>
+  <div tabindex="0" class="focus-trap-hidden" id="lastModalTab" (focus)="findTab($event)" aria-hidden="true"></div>
 </div>

--- a/src/app/modules/modal-shell/modal-shell.component.scss
+++ b/src/app/modules/modal-shell/modal-shell.component.scss
@@ -45,3 +45,24 @@ h1 {
     max-height: 100vh;
     overflow-y:auto;
 }
+
+.modal-header-content {
+  flex: 1;
+
+  ::ng-deep {
+    // Override to ensure the first element (which will likely be a header element) doesn't have the default space
+    // at the top, so that it aligns with the close button
+    :first-child {
+      margin-top: 0;
+      padding-top: 0;
+    }
+  }
+}
+
+.modal-header-close-button {
+  ::ng-deep {
+    button {
+      text-decoration: none;
+    }
+  }
+}

--- a/src/app/modules/modal-shell/modal-shell.component.ts
+++ b/src/app/modules/modal-shell/modal-shell.component.ts
@@ -9,7 +9,7 @@ import {
 @Component({
   selector: 'app-modal-shell',
   templateUrl: './modal-shell.component.html',
-  styleUrls: ['./modal-shell.component.css']
+  styleUrls: ['./modal-shell.component.scss']
 })
 export class AppModalShellComponent {
 


### PR DESCRIPTION
To be inline with the HCD Figma designs, the following changes have been made:

- Change header title to h2 (24px); move to be inline with close button
- Ensure there is no underline (that may appear as a result of ds utility classes)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img width="1442" alt="Screen Shot 2022-04-01 at 1 03 30 PM" src="https://user-images.githubusercontent.com/98362896/161826261-7b1a3293-650d-46d3-b466-23b6a4e14eae.png"></td>
<td>
<img width="1442" alt="Screen Shot 2022-04-01 at 12 33 43 PM" src="https://user-images.githubusercontent.com/98362896/161826330-daa9aa31-8ce3-4d45-8e92-86e288bf4142.png">
</td>
</tr>
</table>