### PR TITLE
fix(app-button): hardcode colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@babel/core": "^7.14.6",
     "@cmsgov/design-system-core": "^3.7.2",
     "@cmsgov/design-system-layout": "^3.7.2",
+    "@cmsgov/design-system-support": "^3.7.2",
     "@storybook/addon-actions": "^6.3.6",
     "@storybook/addon-console": "^1.2.3",
     "@storybook/addon-essentials": "^6.3.6",

--- a/src/app/modules/button/button.component.scss
+++ b/src/app/modules/button/button.component.scss
@@ -7,8 +7,7 @@
 }
 
 .ds-c-button {
-  &:not(.ds-c-button--primary)
-  :not(.ds-c-button-transparent) {
+  &:not(.ds-c-button--primary):not(.ds-c-button--transparent):not([disabled]) {
     border-color: $color-primary-darker;
     color: $color-primary-darker;
   }

--- a/src/app/modules/button/button.component.scss
+++ b/src/app/modules/button/button.component.scss
@@ -1,5 +1,3 @@
-@import '@cmsgov/design-system-support/src/index';
-
 .ds-c-button--transparent[disabled] {
   background-color: transparent;
   border: 1px solid transparent;
@@ -8,7 +6,7 @@
 
 .ds-c-button {
   &:not(.ds-c-button--primary):not(.ds-c-button--transparent):not([disabled]) {
-    border-color: $color-primary-darker;
-    color: $color-primary-darker;
+    border-color: #205493;
+    color: #205493;
   }
 }


### PR DESCRIPTION
The build fails when attempting to import the CMS Design system color variables; opting to just
hard-code them.