### PR TITLE
[HQRPP-32422] Remove Choice's setValue function to work better with formly

### DIFF
--- a/src/app/modules/choice/choice.component.ts
+++ b/src/app/modules/choice/choice.component.ts
@@ -40,7 +40,6 @@ export class AppChoiceComponent implements OnInit, OnChanges {
       this.control = new FormControl();
     }
     this.setDisabled();
-    this.setValue();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -56,14 +55,6 @@ export class AppChoiceComponent implements OnInit, OnChanges {
       this.control?.enable();
     }
   }
-
-  // If the a value is passed into the component and no value is set on the form control,
-  // manually set the value
-  // setValue() {
-  //   if (this.value && !this.control?.value) {
-  //     this.control?.setValue(this.value);
-  //   }
-  // }
 
   onChange($event) {
     this.choiceChange.emit($event);

--- a/src/app/modules/choice/choice.component.ts
+++ b/src/app/modules/choice/choice.component.ts
@@ -59,11 +59,11 @@ export class AppChoiceComponent implements OnInit, OnChanges {
 
   // If the a value is passed into the component and no value is set on the form control,
   // manually set the value
-  setValue() {
-    if (this.value && !this.control?.value) {
-      this.control?.setValue(this.value);
-    }
-  }
+  // setValue() {
+  //   if (this.value && !this.control?.value) {
+  //     this.control?.setValue(this.value);
+  //   }
+  // }
 
   onChange($event) {
     this.choiceChange.emit($event);


### PR DESCRIPTION
Remove the `setVaue` function in `app-choice` component so that it doesn't assign its value to the `formly` model. Since this function already has an [onChange](https://github.com/Bellese/angular-design-system/blob/main/src/app/modules/choice/choice.component.ts#L68-L70) function that broadcasts a change event, setValue seems unnecessary.

This function caused a bug in PVT abstraction where a group of `app-choice` components appeared as if there was no value selected, but the form behaved as if the first option was selected. This caused the skip pattern to break and also caused unselected options to be applied to the model. See gif below for the bug.
![Kapture 2022-07-29 at 14 34 01](https://user-images.githubusercontent.com/39271238/182174475-1119e45a-db4d-43cb-b678-b3f1b2ef4ce1.gif)

Once we remove the setValue function, the form behaves as expected. The first `app-choice` group shows up and doesn't show any subsequent questions until the user has made a selection. See gif below for the fix.
![Kapture 2022-07-29 at 14 24 29](https://user-images.githubusercontent.com/39271238/182174732-3ed29ac2-4fb2-4630-b908-0e4ebfee6d6f.gif)

Fixes [HQRPP-32422](https://qnetjira.cms.gov/browse/HQRPP-32422)