### PR TITLE
fix(app-drop-down) spelling error aria-labeledby -> aria-labelledby

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -404,12 +404,12 @@ TABLE AND PAGINATION
 </app-drop-down>
 <br>
 
-<span id="dropdown-external-label"><b>Drop down - aria-labeledby, no label: </b></span>
+<span id="dropdown-external-label"><b>Drop down - aria-labelledby, no label: </b></span>
 <app-drop-down
   [options] = 'dropDown'
   selectClass = 'ds-c-field--medium'
-  id = 'aria-labeledby-no-label'
-  ariaLabeledby='dropdown-external-label'
+  id = 'aria-labelledby-no-label'
+  ariaLabelledby='dropdown-external-label'
   errorMessage = 'please input correct response'
   [error] = false
   dataAutoId = 'testingID-dropdown-basic'

--- a/src/app/modules/drop-down/drop-down.component.html
+++ b/src/app/modules/drop-down/drop-down.component.html
@@ -34,7 +34,7 @@
   [ngClass]="{ 'ds-c-field--error': error, disabled: disabled }"
   name="options"
   attr.aria-label="{{ attr.select.ariaLabel }}"
-  attr.aria-labeledby="{{ attr.select.ariaLabeledby }}"
+  attr.aria-labelledby="{{ attr.select.ariaLabelledby }}"
   (change)="selectOption($event)"
   attr.data-auto-id="{{ dataAutoId }}"
   [formControl]="control"

--- a/src/app/modules/drop-down/drop-down.component.ts
+++ b/src/app/modules/drop-down/drop-down.component.ts
@@ -11,7 +11,7 @@ export class AppDropDownComponent implements OnInit, OnChanges {
   @Input() labelClass: string;
   @Input() selectClass: string;
   @Input() ariaLabel: string;
-  @Input() ariaLabeledby: string;
+  @Input() ariaLabelledby: string;
   @Input() id: string | number = 1;
   @Input() defaultSelected = 0;
   @Input() defaultSelectedValue: string = null;
@@ -43,11 +43,11 @@ export class AppDropDownComponent implements OnInit, OnChanges {
     const selectId = `dropdown-${this.id}`;
     const labelId = this.labelName ? `${selectId}-label` : null;
 
-    // If a label is defined, the select should use aria-labeledby instead of aria-label
+    // If a label is defined, the select should use aria-labelledby instead of aria-label
     // so that the screen reader doesn't "stutter" when using "reading" commands, and
     // tabbing/focus-driven behavior is preserved.
     //
-    // Also allow explicitly assigning aria-labeledby in case there is no label,
+    // Also allow explicitly assigning aria-labelledby in case there is no label,
     // i.e. we wish to use dropdown in a table, and some other column value should
     // effectively "label" it.
     this.attr = {
@@ -56,7 +56,7 @@ export class AppDropDownComponent implements OnInit, OnChanges {
       },
       select: {
         id: selectId,
-        ariaLabeledby: this.ariaLabeledby || labelId,
+        ariaLabelledby: this.ariaLabelledby || labelId,
         ariaLabel: labelId ? null : this.ariaLabel,
       },
     }


### PR DESCRIPTION
Before, it was adding a custom attribute with the `aria-labeledby` typo - which didn't do anything :(

This seems to work as expected with Mac's VoiceOver.