### PR TITLE
feat(DataTestDirective): using hqrDataTest in HTML templates sets data-test attribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bellese/angular-design-system",
-  "version": "5.0.0",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -66,6 +66,30 @@
         i have added more examples
 </app-alert> -->
 
+<h2>Alert</h2>
+<span><b>Alert - all options: </b></span>
+<app-alert
+  variation="error"
+  heading="Error Heading Text"
+  hideIcon=true
+  hideClose=true
+  dataAutoId="todo-deprecate-this"
+  dataTest="alert-all-options"
+>"Error" variation example with all options set by user</app-alert>
+
+<span><b>Warn - all possible data-test: </b></span>
+<app-alert
+  variation="warn"
+  heading="Warn Heading Text"
+  hideIcon=true
+  dataTest="alert-all-data-test"
+>"Warn" variation example. Inspect source to see data-test values.</app-alert>
+
+<span><b>Alert - minimum, only heading: </b></span>
+<app-alert
+  heading="Only Set the Heading"
+></app-alert>
+
   <!-- BAR GRAPH COMPONENT EXAMPLE
 <app-bar-graph
     [data]="barData"
@@ -367,51 +391,66 @@ TABLE AND PAGINATION
 
 <h2>DROP DOWN</h2>
 <app-drop-down
-  [options] = 'dropDown'
-  labelName = 'Drop down - basic'
-  selectClass = 'ds-c-field--medium'
-  id = 'basic'
-  [defaultSelected] = 2
-  errorMessage = 'please input correct response'
-  [error] = false
-  dataAutoId = 'testingID-dropdown-basic'
-  (selectedOption) = 'announce($event)'>
+  [options]='dropDown'
+  labelName='Drop down - basic'
+  selectClass='ds-c-field--medium'
+  id='basic'
+  [defaultSelected]=2
+  errorMessage='please input correct response'
+  [error]=false
+  dataAutoId='testingID-dropdown-basic'
+  (selectedOption)='announce($event)'>
+</app-drop-down>
+<br>
+
+<app-drop-down
+  [options]='dropDown'
+  labelName='Drop down with alerts - inspect source to see data-test'
+  selectClass='ds-c-field--medium'
+  id='dropdown-data-test'
+  [defaultSelected]=2
+  errorMessage='please input correct response'
+  [error]=false
+  dataTest='testID-dropdown-alertmessages'
+  [alertMessageList]="alertMessageList"
+  alertVariation="error"
+  (selectedOption)='announce($event)'>
 </app-drop-down>
 <br>
 
 <span><b>Drop down - no label: </b></span>
 <app-drop-down
-  [options] = 'dropDown'
-  selectClass = 'ds-c-field--medium'
-  id = 'no-label'
-  errorMessage = 'please input correct response'
-  [error] = false
-  dataAutoId = 'testingID-dropdown-basic'
-  (selectedOption) = 'announce($event)'>
+  [options]='dropDown'
+  selectClass='ds-c-field--medium'
+  id='no-label'
+  errorMessage='please input correct response'
+  [error]=false
+  dataAutoId='testingID-dropdown-basic'
+  (selectedOption)='announce($event)'>
 </app-drop-down>
 <br>
 
 <span><b>Drop down - aria-label, no label: </b></span>
 <app-drop-down
-  [options] = 'dropDown'
-  selectClass = 'ds-c-field--medium'
-  id = 'aria-label-no-label'
+  [options]='dropDown'
+  selectClass='ds-c-field--medium'
+  id='aria-label-no-label'
   ariaLabel='custom aria label'
-  errorMessage = 'please input correct response'
-  [error] = false
-  dataAutoId = 'testingID-dropdown-basic'
-  (selectedOption) = 'announce($event)'>
+  errorMessage='please input correct response'
+  [error]=false
+  dataAutoId='testingID-dropdown-basic'
+  (selectedOption)='announce($event)'>
 </app-drop-down>
 <br>
 
 <span id="dropdown-external-label"><b>Drop down - aria-labelledby, no label: </b></span>
 <app-drop-down
-  [options] = 'dropDown'
-  selectClass = 'ds-c-field--medium'
-  id = 'aria-labelledby-no-label'
+  [options]='dropDown'
+  selectClass='ds-c-field--medium'
+  id='aria-labelledby-no-label'
   ariaLabelledby='dropdown-external-label'
-  errorMessage = 'please input correct response'
-  [error] = false
-  dataAutoId = 'testingID-dropdown-basic'
-  (selectedOption) = 'announce($event)'>
+  errorMessage='please input correct response'
+  [error]=false
+  dataAutoId='testingID-dropdown-basic'
+  (selectedOption)='announce($event)'>
 </app-drop-down>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -74,16 +74,16 @@
   hideIcon=true
   hideClose=true
   dataAutoId="todo-deprecate-this"
-  dataTest="alert-all-options"
+  hqrDataTest="alert-all-options"
 >"Error" variation example with all options set by user</app-alert>
 
-<span><b>Warn - all possible data-test: </b></span>
+<span><b>Warn - data-test: </b></span>
 <app-alert
   variation="warn"
   heading="Warn Heading Text"
   hideIcon=true
-  dataTest="alert-all-data-test"
->"Warn" variation example. Inspect source to see data-test values.</app-alert>
+  hqrDataTest="alert-all-data-test"
+>"Warn" variation example. Inspect source to see data-test.</app-alert>
 
 <span><b>Alert - minimum, only heading: </b></span>
 <app-alert
@@ -411,7 +411,7 @@ TABLE AND PAGINATION
   [defaultSelected]=2
   errorMessage='please input correct response'
   [error]=false
-  dataTest='testID-dropdown-alertmessages'
+  hqrDataTest='testID-dropdown-alertmessages'
   [alertMessageList]="alertMessageList"
   alertVariation="error"
   (selectedOption)='announce($event)'>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -75,6 +75,7 @@ export class AppComponent implements OnInit {
       value: 'op3',
     },
   ];
+  alertMessageList = ['Alert message 1', 'Alert message 2'];
 
   tabs = [
     {

--- a/src/app/directives/data-test.directive.spec.ts
+++ b/src/app/directives/data-test.directive.spec.ts
@@ -8,17 +8,17 @@ import { DataTestDirective } from './data-test.directive';
 let fixture: ComponentFixture<TestComponent>;
 let des: DebugElement[];
 
-beforeEach(() => {
-  fixture = TestBed.configureTestingModule({
-    declarations: [ DataTestDirective, TestComponent]
-  })
-  .createComponent(TestComponent);
-
-  fixture.detectChanges();
-  des = fixture.debugElement.queryAll(By.directive(DataTestDirective));
-})
-
 describe('DataTestDirective', () => {
+  beforeEach(() => {
+    fixture = TestBed.configureTestingModule({
+      declarations: [ DataTestDirective, TestComponent]
+    })
+    .createComponent(TestComponent);
+
+    fixture.detectChanges();
+    des = fixture.debugElement.queryAll(By.directive(DataTestDirective));
+  })
+
   it('should find elements with hqrDataTest assigned', () => {
     expect(des.length).toBeGreaterThan(0);
   });

--- a/src/app/directives/data-test.directive.spec.ts
+++ b/src/app/directives/data-test.directive.spec.ts
@@ -1,0 +1,8 @@
+import { DataTestDirective } from './data-test.directive';
+
+describe('DataTestDirective', () => {
+  it('should create an instance', () => {
+    const directive = new DataTestDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/directives/data-test.directive.spec.ts
+++ b/src/app/directives/data-test.directive.spec.ts
@@ -1,8 +1,30 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { DataTestDirective } from './data-test.directive';
 
+@Component({ template: `<div hqrDataTest="yay"></div>` }) class TestComponent { }
+
+let fixture: ComponentFixture<TestComponent>;
+let des: DebugElement[];
+
+beforeEach(() => {
+  fixture = TestBed.configureTestingModule({
+    declarations: [ DataTestDirective, TestComponent]
+  })
+  .createComponent(TestComponent);
+
+  fixture.detectChanges();
+  des = fixture.debugElement.queryAll(By.directive(DataTestDirective));
+})
+
 describe('DataTestDirective', () => {
-  it('should create an instance', () => {
-    const directive = new DataTestDirective();
-    expect(directive).toBeTruthy();
+  it('should find elements with hqrDataTest assigned', () => {
+    expect(des.length).toBeGreaterThan(0);
+  });
+
+  it('should find elements with data-test and assigned value', () => {
+    const elem = des[0];
+    expect(elem.attributes['data-test']).toBe('yay');
   });
 });

--- a/src/app/directives/data-test.directive.ts
+++ b/src/app/directives/data-test.directive.ts
@@ -1,10 +1,23 @@
-import { Directive } from '@angular/core';
+import { Directive, ElementRef, Input, OnInit, Renderer2 } from '@angular/core';
 
 @Directive({
-  selector: '[appDataTest]'
+  selector: '[hqrTestId]'
 })
-export class DataTestDirective {
+export class DataTestDirective implements OnInit {
+  @Input() hqrTestId!: string;
 
-  constructor() { }
+  element: any; // must be 'any' to match el.nativeElement
 
+  constructor(private el: ElementRef, private renderer: Renderer2) {
+    this.element = el.nativeElement;
+  }
+
+  ngOnInit(): void {
+    this.inputToAttribute()
+  }
+
+  inputToAttribute() {
+    this.renderer.setAttribute(this.element, 'data-test', this.hqrTestId);
+    this.renderer.removeAttribute(this.element, 'hqrTestId');
+  }
 }

--- a/src/app/directives/data-test.directive.ts
+++ b/src/app/directives/data-test.directive.ts
@@ -1,0 +1,10 @@
+import { Directive } from '@angular/core';
+
+@Directive({
+  selector: '[appDataTest]'
+})
+export class DataTestDirective {
+
+  constructor() { }
+
+}

--- a/src/app/directives/data-test.directive.ts
+++ b/src/app/directives/data-test.directive.ts
@@ -1,10 +1,10 @@
 import { Directive, ElementRef, Input, OnInit, Renderer2 } from '@angular/core';
 
 @Directive({
-  selector: '[hqrTestId]'
+  selector: '[hqrDataTest]'
 })
 export class DataTestDirective implements OnInit {
-  @Input() hqrTestId!: string;
+  @Input() hqrDataTest!: string;
 
   element: any; // must be 'any' to match el.nativeElement
 
@@ -17,7 +17,7 @@ export class DataTestDirective implements OnInit {
   }
 
   inputToAttribute() {
-    this.renderer.setAttribute(this.element, 'data-test', this.hqrTestId);
+    this.renderer.setAttribute(this.element, 'data-test', this.hqrDataTest);
     this.renderer.removeAttribute(this.element, 'hqrTestId');
   }
 }

--- a/src/app/directives/directive.module.ts
+++ b/src/app/directives/directive.module.ts
@@ -1,13 +1,15 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FileUploadDragDropDirective } from './file-upload-drag-drop.directive';
+import { DataTestDirective } from './data-test.directive';
 
 @NgModule({
   imports: [
     CommonModule
   ],
   declarations: [
-    FileUploadDragDropDirective
+    FileUploadDragDropDirective,
+    DataTestDirective
   ],
   exports: [
     FileUploadDragDropDirective

--- a/src/app/directives/directive.module.ts
+++ b/src/app/directives/directive.module.ts
@@ -12,7 +12,8 @@ import { DataTestDirective } from './data-test.directive';
     DataTestDirective
   ],
   exports: [
-    FileUploadDragDropDirective
+    FileUploadDragDropDirective,
+    DataTestDirective,
   ]
 })
 export class DirectiveModule { }

--- a/src/app/modules/alert/alert.component.html
+++ b/src/app/modules/alert/alert.component.html
@@ -4,18 +4,24 @@
     hideIcon ? 'hide-icon' : null
   }} ds-c-alert--{{ hideClose ? 'hide-close' : 'close' }}"
   attr.data-auto-id="{{ dataAutoId }}"
+  attr.data-test="{{ dataTestVals.outer }}"
 >
   <div class="close">
     <button
       *ngIf="!hideClose"
       (click)="hide = true"
       class="ds-c-button ds-c-button--transparent ds-c-dialog__close"
+      attr.data-test="{{ dataTestVals.close }}"
     >
       Close
     </button>
   </div>
   <div class="ds-c-alert__body">
-    <div class="ds-c-alert__heading" *ngIf="heading">
+    <div
+      class="ds-c-alert__heading"
+      *ngIf="heading"
+      attr.data-test="{{ dataTestVals.heading }}"
+    >
       {{heading}}
     </div>
     <div class="ds-c-alert__text">

--- a/src/app/modules/alert/alert.component.html
+++ b/src/app/modules/alert/alert.component.html
@@ -4,14 +4,12 @@
     hideIcon ? 'hide-icon' : null
   }} ds-c-alert--{{ hideClose ? 'hide-close' : 'close' }}"
   attr.data-auto-id="{{ dataAutoId }}"
-  attr.data-test="{{ dataTestVals.outer }}"
 >
   <div class="close">
     <button
       *ngIf="!hideClose"
       (click)="hide = true"
       class="ds-c-button ds-c-button--transparent ds-c-dialog__close"
-      attr.data-test="{{ dataTestVals.close }}"
     >
       Close
     </button>
@@ -20,7 +18,6 @@
     <div
       class="ds-c-alert__heading"
       *ngIf="heading"
-      attr.data-test="{{ dataTestVals.heading }}"
     >
       {{heading}}
     </div>

--- a/src/app/modules/alert/alert.component.ts
+++ b/src/app/modules/alert/alert.component.ts
@@ -11,22 +11,6 @@ export class AlertComponent {
     @Input() hideIcon = false;
     @Input() hideClose = false;
     @Input() dataAutoId: string;
-    @Input() dataTest: string;
 
     hide: boolean;
-    dataTestVals = {
-      outer: null,
-      close: null,
-      heading: null,
-    };
-
-    ngOnInit() {
-      if (this.dataTest) {
-        this.dataTestVals = {
-          outer: `${this.dataTest}-${this.variation}`,
-          close: `${this.dataTest}-close`,
-          heading: `${this.dataTest}-heading`,
-        };
-      }
-    }
 }

--- a/src/app/modules/alert/alert.component.ts
+++ b/src/app/modules/alert/alert.component.ts
@@ -11,7 +11,22 @@ export class AlertComponent {
     @Input() hideIcon = false;
     @Input() hideClose = false;
     @Input() dataAutoId: string;
+    @Input() dataTest: string;
 
     hide: boolean;
+    dataTestVals = {
+      outer: null,
+      close: null,
+      heading: null,
+    };
 
+    ngOnInit() {
+      if (this.dataTest) {
+        this.dataTestVals = {
+          outer: `${this.dataTest}-${this.variation}`,
+          close: `${this.dataTest}-close`,
+          heading: `${this.dataTest}-heading`,
+        };
+      }
+    }
 }

--- a/src/app/modules/drop-down/drop-down.component.html
+++ b/src/app/modules/drop-down/drop-down.component.html
@@ -1,9 +1,9 @@
+<!-- TODO: deprecate dataAutoId -->
 <label
   *ngIf="labelName"
   [id]="attr.label.id"
   [ngClass]="labelClass"
   class="ds-c-label ds-u-margin-top--0 ds-u-sans"
-  attr.data-test="{{ attr.dataTest.label }}"
   [for]="attr.select.id"
 >
   <span class="ds-u-font-weight--bold">{{ labelName }}</span>
@@ -14,12 +14,11 @@
 </label>
 
 <ng-template [ngIf]="alertMessageList && alertMessageList?.length">
-  <div class="ds-u-margin-y--2" attr.data-test="{{ attr.dataTest.alerts }}">
+  <div class="ds-u-margin-y--2">
     <!-- We can't really guarantee or control uniqueness of items in alertMessageList,
       at least not whether they're unique alertVariation values...
     Best to put test ID on outer "container" element and let engineers
     control the behavior/expectations in UIs and tests. -->
-    <!-- TODO: deprecate dataAutoId usage in dropdown alerts. -->
     <app-alert
       dataAutoId="{{ id + '-' + alertVariation }}"
       [hideClose]="true"
@@ -47,7 +46,6 @@
   attr.aria-labelledby="{{ attr.select.ariaLabelledby }}"
   (change)="selectOption($event)"
   attr.data-auto-id="{{ dataAutoId }}"
-  attr.data-test="{{ attr.dataTest.select }}"
   [formControl]="control"
   [formlyAttributes]="formlyAttributes"
 >

--- a/src/app/modules/drop-down/drop-down.component.html
+++ b/src/app/modules/drop-down/drop-down.component.html
@@ -3,6 +3,7 @@
   [id]="attr.label.id"
   [ngClass]="labelClass"
   class="ds-c-label ds-u-margin-top--0 ds-u-sans"
+  attr.data-test="{{ attr.dataTest.label }}"
   [for]="attr.select.id"
 >
   <span class="ds-u-font-weight--bold">{{ labelName }}</span>
@@ -13,8 +14,17 @@
 </label>
 
 <ng-template [ngIf]="alertMessageList && alertMessageList?.length">
-  <div class="ds-u-margin-y--2">
-    <app-alert dataAutoId="{{ id + '-' + alertVariation }}" [hideClose]="true" variation="{{ alertVariation }}">
+  <div class="ds-u-margin-y--2" attr.data-test="{{ attr.dataTest.alerts }}">
+    <!-- We can't really guarantee or control uniqueness of items in alertMessageList,
+      at least not whether they're unique alertVariation values...
+    Best to put test ID on outer "container" element and let engineers
+    control the behavior/expectations in UIs and tests. -->
+    <!-- TODO: deprecate dataAutoId usage in dropdown alerts. -->
+    <app-alert
+      dataAutoId="{{ id + '-' + alertVariation }}"
+      [hideClose]="true"
+      variation="{{ alertVariation }}"
+    >
       <div *ngIf="alertMessageList.length > 1; else singleAlert">
         <div *ngFor="let alertMessage of alertMessageList">
           <li>{{ alertMessage }}</li>
@@ -37,6 +47,7 @@
   attr.aria-labelledby="{{ attr.select.ariaLabelledby }}"
   (change)="selectOption($event)"
   attr.data-auto-id="{{ dataAutoId }}"
+  attr.data-test="{{ attr.dataTest.select }}"
   [formControl]="control"
   [formlyAttributes]="formlyAttributes"
 >

--- a/src/app/modules/drop-down/drop-down.component.ts
+++ b/src/app/modules/drop-down/drop-down.component.ts
@@ -19,6 +19,7 @@ export class AppDropDownComponent implements OnInit, OnChanges {
   @Input() errorMessage: string;
   @Input() error: boolean;
   @Input() dataAutoId: string;
+  @Input() dataTest: string;
   @Input() disabled: boolean;
   @Input() control: FormControl;
   @Input() formlyAttributes = {};
@@ -59,6 +60,19 @@ export class AppDropDownComponent implements OnInit, OnChanges {
         ariaLabelledby: this.ariaLabelledby || labelId,
         ariaLabel: labelId ? null : this.ariaLabel,
       },
+      dataTest: {
+        label: null,
+        alerts: null,
+        select: null,
+      }
+    };
+
+    if (this.dataTest) {
+      this.attr.dataTest = {
+        label: `${this.dataTest}-label`,
+        alerts: `${this.dataTest}-alerts`,
+        select: `${this.dataTest}-select`,
+      };
     }
   }
 

--- a/src/app/modules/drop-down/drop-down.component.ts
+++ b/src/app/modules/drop-down/drop-down.component.ts
@@ -19,7 +19,6 @@ export class AppDropDownComponent implements OnInit, OnChanges {
   @Input() errorMessage: string;
   @Input() error: boolean;
   @Input() dataAutoId: string;
-  @Input() dataTest: string;
   @Input() disabled: boolean;
   @Input() control: FormControl;
   @Input() formlyAttributes = {};
@@ -60,20 +59,7 @@ export class AppDropDownComponent implements OnInit, OnChanges {
         ariaLabelledby: this.ariaLabelledby || labelId,
         ariaLabel: labelId ? null : this.ariaLabel,
       },
-      dataTest: {
-        label: null,
-        alerts: null,
-        select: null,
-      }
     };
-
-    if (this.dataTest) {
-      this.attr.dataTest = {
-        label: `${this.dataTest}-label`,
-        alerts: `${this.dataTest}-alerts`,
-        select: `${this.dataTest}-select`,
-      };
-    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
We're adopting `data-test` as the new "test automation ID" attribute. This lets us...

1. Take a more deliberate approach to making these useful
2. Know where we've reviewed and refactored test IDs (i.e. `data-auto-id` may still be useful, but it likely won't be recently reviewed by test and dev engineers for validity)
3. Take a staged approach to deprecating `data-auto-id`, since it's frequently used in a fragile or noisy way.

This is ready to go for final review. It adds a simple directive that will take something like this in your template...
```html
<div hqrDataTest="first-test-id">My high school poetry</div>
<app-table hqrDataTest="how-did-you-get-this">
  (... eye-roll fuel...)
</app-table>
```

into ...
```html
<div data-test="first-test-id">My high school poetry</div>
<app-table hqrDataTest="how-did-you-get-this">
  (... eye-roll fuel...)
</app-table>
```

... without needing to add `@Input() hqrDataTest: string;` to every single component in this library, or set `[attr.data-test]` in other apps.