### PR TITLE
fix(app-panel): narrow window no longer causes icon, content overlap

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,5 @@
 <section class="ds-l-container preview__grid">
+<br>
   <!-- UNCOMMENT CODE ON THIS PAGE TO SEE EXAMPLES OF COMPONENTS
 <br>
 <br> -->
@@ -65,6 +66,43 @@
         you need to add more document examples<br />
         i have added more examples
 </app-alert> -->
+
+<h2>Panel</h2>
+
+<app-panel
+    (panelClick) = "announce($event)"
+    title ='Accordion Example with a really long title to see if the left icon overlaps.'
+    extTitleClass = ''
+    dataAutoId = 'dataID'
+    [extTitle] = true
+    [expand] = true
+    expandedClass = 'ds-u-fill--gray-lightest ds-u-border-top--0 ds-u-border--1 ds-u-border--dark ds-u-padding--2'
+    [openAll] = false>
+    <span>
+        Additional Title
+    </span>
+    <div>
+        Content Structure
+    </div>
+</app-panel>
+
+<app-panel
+    (panelClick) = "announce($event)"
+    dataAutoId = 'dataID'
+    [extTitle] = true
+    [expand] = true
+    expandedClass = 'ds-u-fill--gray-lightest ds-u-border-top--0 ds-u-border--1 ds-u-border--dark ds-u-padding--2'
+    [openAll] = false>
+    <ng-container>
+      <div>
+        Accordion Example maybe with a button or whatever just to see what happens.
+      </div>
+    </ng-container>
+    <span><app-button>DELETE EVERYTHING</app-button></span>
+    <div>
+      And then everything else. I hope you're enjoying yourself. Lorem Ipsum etc etc etc. At first I thought I'd type "the rain in Spain..." and so forth, then "falls mainly only the plain" triggered "but I get up again" from Chumbawumba's hit song "Tubthumping". What on Earth.
+    </div>
+</app-panel>
 
 <h2>Alert</h2>
 <span><b>Alert - all options: </b></span>

--- a/src/app/modules/button/button.component.ts
+++ b/src/app/modules/button/button.component.ts
@@ -9,7 +9,7 @@ import { ButtonInputTypeEnum } from './button.models';
 export class AppButtonComponent {
   @Input() buttonInputType: ButtonInputTypeEnum = ButtonInputTypeEnum.BUTTON;
   @Input() ariaLabel: string;
-  @Input() buttonType: string;
+  @Input() buttonType: string = 'ds-c-button--primary';
   @Input() buttonID: string;
   @Input() ariaSort: 'ascending' | 'descending' | 'none';
   @Input() dataAutoId: string;

--- a/src/app/modules/panel/panel.component.html
+++ b/src/app/modules/panel/panel.component.html
@@ -28,14 +28,14 @@
       <div class="ds-l-row">
         <!-- Left Icon -->
         <div
-          class="ds-l-col--auto"
+          class="ds-l-col--auto ds-u-padding-right--0"
           [ngClass]="plusIconClass"
           *ngIf="iconPlacement === PanelIconPlacementEnum.LEFT"
         >
           <ng-container *ngTemplateOutlet="plusIcon"></ng-container>
         </div>
         <!-- Title -->
-        <div class="title ds-l-col--auto ds-u-padding-left--0">
+        <div class="title ds-l-col--11 ds-u-justify-content--start">
           <ng-container *ngIf="title; else titleComplex">{{
             titleExpanded && (expand || openAll) ? titleExpanded : title
           }}</ng-container>


### PR DESCRIPTION
# Before
<img width="748" alt="Screen Shot 2022-10-27 at 9 50 57 AM" src="https://user-images.githubusercontent.com/730506/198351674-4dbd091f-09ff-4764-a5f6-cb8c42e501f5.png">

# After
<img width="774" alt="Screen Shot 2022-10-27 at 9 27 48 AM" src="https://user-images.githubusercontent.com/730506/198351747-4cad4ea1-5b55-4e36-8acd-003a4aae9bd3.png">

# And when panel is not constrained by window's width
## Just to verify the left icon, title, right button/text content still land where expected
<img width="1422" alt="Screen Shot 2022-10-27 at 9 51 47 AM" src="https://user-images.githubusercontent.com/730506/198351835-375c6b1d-a9b4-4fa7-9278-883817a2d26e.png">
