### PR TITLE
fix(text-field): 508 - errorMessage uses hidden instead of ngIf

### DIFF
--- a/src/app/modules/text-field/text-field.component.html
+++ b/src/app/modules/text-field/text-field.component.html
@@ -1,7 +1,7 @@
 <label class="ds-c-label" [ngClass]="labelClass" for="{{ id }}">
   <span class="ds-u-font-weight--bold">{{ title }}</span>
   <span *ngIf="hint" class="ds-c-field__hint" [ngClass]="hintClass" role="alert">{{ hint }}</span>
-  <span *ngIf="errorMessage" class="ds-c-field__hint ds-u-color--error" aria-live="polite" [attr.aria-label]="title + ' has error message ' + errorMessage">{{ errorMessage }}</span>
+  <span [hidden]="!errorMessage" aria-live="polite" class="ds-c-field__hint ds-u-color--error" attr.aria-label="{{ title }} error {{ errorMessage }}">{{ errorMessage }}</span>
 </label>
 
 <ng-template [ngIf]="alertMessageList && alertMessageList?.length">


### PR DESCRIPTION
Hopefully this lets JAWS read the `aria-live="polite" aria-label="..."` when the `errorMessage` is no longer hidden. Maybe the `ngIf` wasn't playing nice? Both worked with Mac's VoiceOver 🤷 