### PR TITLE
Revert "fix(text-field): role=alert changed to aria-live polite"

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -182,15 +182,6 @@
     errorMessage = 'please check me'>
 </app-choice> -->
 
-<app-choice
-  value="radio-selection-1"
-  [showTitle]="true"
-  label="radio label text"
-  inputType="radio"
-  [isChecked]="false"
-  >
-</app-choice>
-
   <!-- CIRCLE GRAPH COMPONENT EXAMPLE
 <app-circle-graph
     dataAutoId = 'testingID'
@@ -527,15 +518,13 @@ TABLE AND PAGINATION
 
 <h2>TEXT FIELD</h2>
 
-<app-button (click)="textFieldErrorToggle(textField)">Toggle Text Field Errors</app-button><br />
-
 <app-text-field
   alertVariation="info"
   required="true"
   defaultValue="some value"
   title="Text field with both require and aria-required"
   ariaLabel="bogus aria-label"
-  [errorMessage]="textField.errorMessage"
+  errorMessage="Look what you've done"
   id="text-field-id-1"
   inputClass="ds-u-font-weight--normal"
   labelClass="ds-u-font-weight--bold"
@@ -555,7 +544,7 @@ TABLE AND PAGINATION
   defaultValue="some value"
   title="Multi-line Text field with both require and aria-required"
   ariaLabel="bogus aria-label"
-  [errorMessage]="textField.errorMessage"
+  errorMessage="Look what you've done"
   id="text-field-id-2"
   inputClass="ds-u-font-weight--normal"
   labelClass="ds-u-font-weight--bold"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -77,10 +77,6 @@ export class AppComponent implements OnInit {
   ];
   alertMessageList = ['Alert message 1', 'Alert message 2'];
 
-  textField = {
-    errorMessage: 'This is a required field',
-  }
-
   tabs = [
     {
       title: 'tab1',
@@ -474,13 +470,5 @@ export class AppComponent implements OnInit {
 
   showToast(message, title, variation) {
     this.toastService.showToast(message, title, variation);
-  }
-
-  textFieldErrorToggle(tf) {
-    if (!tf.errorMessage) {
-      tf.errorMessage = 'This is a required field';
-    } else {
-      tf.errorMessage = null;
-    }
   }
 }

--- a/src/app/modules/choice/choice.component.html
+++ b/src/app/modules/choice/choice.component.html
@@ -24,8 +24,6 @@
   name="{{ groupName }}"
   [attr.value]="value"
   [checked]="isChecked"
-  [attr.aria-checked]="isChecked"
-  [attr.role]="inputType"
   attr.data-auto-id="{{ dataAutoId }}"
   (change)="onChange($event)"
   attr.aria-label="{{ ariaLabel }}"

--- a/src/app/modules/text-field/text-field.component.html
+++ b/src/app/modules/text-field/text-field.component.html
@@ -1,7 +1,7 @@
 <label class="ds-c-label" [ngClass]="labelClass" for="{{ id }}">
   <span class="ds-u-font-weight--bold">{{ title }}</span>
   <span *ngIf="hint" class="ds-c-field__hint" [ngClass]="hintClass" role="alert">{{ hint }}</span>
-  <span *ngIf="errorMessage" class="ds-c-field__hint ds-u-color--error" aria-live="polite" [attr.aria-label]="title + ' has error message ' + errorMessage">{{ errorMessage }}</span>
+  <span *ngIf="errorMessage" class="ds-c-field__hint ds-u-color--error" role="alert">{{ errorMessage }}</span>
 </label>
 
 <ng-template [ngIf]="alertMessageList && alertMessageList?.length">


### PR DESCRIPTION
Reverts Bellese/angular-design-system#343

I couldn't find a clean way in the product app that respected these changes. We'll need to try again later when the rest of the containing app(s) are under one repo, and we can undo all the abuse of `aria-live="assertive"` etc elsewhere in the DOM at any given time.