### PR TITLE
fix(modal-generic.component.ts): On modal close, put focus back on originating button (for both modal close buttons)

### DIFF
--- a/src/app/modules/modal-shell/modal-generic/modal-generic.component.ts
+++ b/src/app/modules/modal-shell/modal-generic/modal-generic.component.ts
@@ -21,6 +21,7 @@ export class ModalGenericComponent implements OnInit {
 
   handleClose($event) {
     this.closeModal.emit($event);
+    document.getElementById(this.modalData.id).focus();
   }
 
   setOnConfirmData(data) {
@@ -34,6 +35,5 @@ export class ModalGenericComponent implements OnInit {
     } else if (buttonFunc) {
       buttonFunc(this.onConfirmData);
     }
-    document.getElementById(this.modalData.id).focus();
   }
 }


### PR DESCRIPTION
Ensures tool tip focus is returned to tool tip button after modal close.